### PR TITLE
Add subscription free property and latestBreach() method to BreachEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [6.3.0] - 2023-10-28
+
+### Added
+- Add `subscriptionFree` property to `BreachEntity`.
+- Add `latestBreach()` method.
+
 ## [6.2.0] - 2023-06-20
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,10 @@ php82:
 
 stan82:
 	@docker compose exec -e XDEBUG_MODE=off -w /opt/project php82 composer stan
+
+php83:
+	@docker compose exec -e XDEBUG_MODE=off -w /opt/project php83 /bin/sh
+
+stan83:
+	@docker compose exec -e XDEBUG_MODE=off -w /opt/project php83 composer stan
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,17 @@ services:
 
   php82:
     container_name: php82
-    image: digiserv/php8-cli:8.2.7-alpine
+    image: digiserv/php8-cli:8.2.11-alpine
     volumes:
       - ./:/opt/project
     entrypoint: /bin/sh
     tty: true
+
+  php83:
+    container_name: php83
+    image: digiserv/php8-cli:8.3.0RC4-alpine
+    volumes:
+      - ./:/opt/project
+    entrypoint: /bin/sh
+    tty: true
+  

--- a/src/Breach/BreachSiteEntity.php
+++ b/src/Breach/BreachSiteEntity.php
@@ -41,6 +41,8 @@ class BreachSiteEntity
 
     public readonly string $logoPath;
 
+    public readonly bool $subscriptionFree;
+
     public function __construct(?stdClass $data = null)
     {
         if (null === $data) {
@@ -62,6 +64,7 @@ class BreachSiteEntity
         $this->retired = $data->IsRetired;
         $this->spamList = $data->IsSpamList;
         $this->malware = $data->IsMalware;
+        $this->subscriptionFree = $data->IsSubscriptionFree;
         $this->logoPath = $data->LogoPath;
     }
 

--- a/src/Breach/BreachSiteTruncatedEntity.php
+++ b/src/Breach/BreachSiteTruncatedEntity.php
@@ -3,15 +3,20 @@
 namespace Icawebdesign\Hibp\Breach;
 
 use stdClass;
+use RuntimeException;
 
 class BreachSiteTruncatedEntity
 {
     public readonly string $name;
+    public readonly string $title;
 
-    public function __construct(stdClass $data)
+    public function __construct(?stdClass $data = null)
     {
-        if (isset($data->Name)) {
-            $this->name = $data->Name;
+        if (null === $data) {
+            throw new RuntimeException('Invalid BreachSite data');
         }
+
+        $this->name = $data->Name;
+        $this->title = $data->Title;
     }
 }

--- a/tests/_responses/breaches/breaches.json
+++ b/tests/_responses/breaches/breaches.json
@@ -20,6 +20,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree":false,
     "IsMalware": false
   },
   {
@@ -41,6 +42,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree": false,
     "IsMalware": false
   },
   {
@@ -65,6 +67,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree": false,
     "IsMalware": false
   },
   {
@@ -87,6 +90,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree": false,
     "IsMalware": false
   },
   {
@@ -108,6 +112,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree": false,
     "IsMalware": false
   },
   {
@@ -130,6 +135,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree": false,
     "IsMalware": false
   },
   {
@@ -156,6 +162,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree": false,
     "IsMalware": false
   },
   {
@@ -178,6 +185,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree": false,
     "IsMalware": false
   }
 ]

--- a/tests/_responses/breaches/breaches_domain_filter.json
+++ b/tests/_responses/breaches/breaches_domain_filter.json
@@ -20,6 +20,7 @@
     "IsSensitive": false,
     "IsRetired": false,
     "IsSpamList": false,
+    "IsSubscriptionFree": false,
     "IsMalware": false
   }
 ]

--- a/tests/_responses/breaches/single_account_breach.json
+++ b/tests/_responses/breaches/single_account_breach.json
@@ -19,5 +19,6 @@
   "IsSensitive": false,
   "IsRetired": false,
   "IsSpamList": false,
+  "IsSubscriptionFree": false,
   "IsMalware": false
 }


### PR DESCRIPTION
Refactor breach filtering.
Add subscriptionFree property to `BreachEntity`.
`IsSubscriptionFree` was added to the API recently regarding domain lookups.
https://haveibeenpwned.com/API/v3#BreachModel.
Add `latestBreach()` method to breach lookup.
Test against PHP `8.3.0 RC4`.